### PR TITLE
Fix unit conversion for multiple tracked objects

### DIFF
--- a/src/MotionTrackerBeta/functions/transforms.py
+++ b/src/MotionTrackerBeta/functions/transforms.py
@@ -20,10 +20,7 @@ import numpy as np
 def rad2deg_(data):
     """Converts the data in the array from radian to edgrees"""
 
-    if data.shape[1] > 1:
-        data[:, [1, data.shape[1] - 1]] = 180 / np.pi * data[:, [1, data.shape[1] - 1]]
-    else:
-        data[:, 1] = data[:, 1] * 180 / np.pi
+    data[:, 1:] = 180 / np.pi * data[:, 1:]
     return data
 
 
@@ -31,12 +28,7 @@ def pix2mm(data, mm_per_pix):
     """Using the ruler it coverts the data to mm"""
 
     if mm_per_pix is not None:
-        if data.shape[1] > 1:
-            data[:, [1, data.shape[1] - 1]] = (
-                mm_per_pix * data[:, [1, data.shape[1] - 1]]
-            )
-        else:
-            data[:, 1] = data[:, 1] * mm_per_pix
+        data[:, 1:] = mm_per_pix * data[:, 1:]
         return data
     else:
         return None
@@ -46,12 +38,7 @@ def pix2m(data, mm_per_pix):
     """Using the ruler it coverts the data to m"""
 
     if mm_per_pix is not None:
-        if data.shape[1] > 1:
-            data[:, [1, data.shape[1] - 1]] = (
-                mm_per_pix/1000 * data[:, [1, data.shape[1] - 1]]
-            )
-        else:
-            data[:, 1] = data[:, 1] * mm_per_pix/1000
+        data[:, 1:] = mm_per_pix / 1000 * data[:, 1:]
         return data
     else:
         return None


### PR DESCRIPTION
When exporting/plotting data for more than 1 object only the first and last column of the data were unit-converted correctly.

The other columns were skipped leaving the data inconsistent.

I don't know if it's a bug or if there was a reason why you did the array manipulation.