### PR TITLE
Add configurable marker size for tracking points

### DIFF
--- a/src/MotionTrackerBeta/functions/display.py
+++ b/src/MotionTrackerBeta/functions/display.py
@@ -26,6 +26,7 @@ def display_objects(
     box_bool,
     point_bool,
     trajectory_length,
+    marker_size=20,
 ):
     """Draws tracked object onto the video frame for playback and export"""
     for obj in objects:
@@ -54,7 +55,7 @@ def display_objects(
                 if point_bool:
                     x, y = obj.point_path[int(pos - section_start + 1)]
                     frame = cv2.drawMarker(
-                        frame, (int(x), int(y)), (0, 0, 255), 0, thickness=2
+                        frame, (int(x), int(y)), (0, 0, 255), 0, markerSize=marker_size, thickness=2
                     )
                     if pos - section_start < trajectory_length:
                         for i in range(1, int(pos - section_start + 2)):

--- a/src/MotionTrackerBeta/widgets/export.py
+++ b/src/MotionTrackerBeta/widgets/export.py
@@ -45,6 +45,7 @@ class ExportingThread(QThread):
         box_bool,
         point_bool,
         trajectory_lenght,
+        marker_size=20,
     ):
         """Initialization"""
         self.camera = camera
@@ -57,6 +58,7 @@ class ExportingThread(QThread):
         self.box_bool = box_bool
         self.point_bool = point_bool
         self.trajectory_length = trajectory_lenght
+        self.marker_size = marker_size
 
         # call parent function
         super(ExportingThread, self).__init__()
@@ -102,6 +104,7 @@ class ExportingThread(QThread):
                 self.box_bool,
                 self.point_bool,
                 self.trajectory_length,
+                self.marker_size,
             )
 
             # write frame to file


### PR DESCRIPTION
Adds a slider in the "Objects to track" panel to adjust the red cross marker size for tracked points.

Works in live preview and exported videos.