### PR TITLE
Allow point-only tracking without requiring region selection

### DIFF
--- a/src/MotionTrackerBeta/classes/classes.py
+++ b/src/MotionTrackerBeta/classes/classes.py
@@ -21,7 +21,7 @@ import numpy as np
 class Motion:
     """Class that stores every detail of the objects being tracked"""
 
-    def __init__(self, name, point, rectangle, visible=True):
+    def __init__(self, name, point, rectangle, visible=True, rectangle_visible=True):
         # identification
         self.name = name
 
@@ -29,6 +29,7 @@ class Motion:
         self.point = point
         self.rectangle = rectangle
         self.visible = visible
+        self.rectangle_visible = rectangle_visible  # False if user doesn't set one
 
         # output, raw data
         self.rectangle_path = []

--- a/src/MotionTrackerBeta/functions/display.py
+++ b/src/MotionTrackerBeta/functions/display.py
@@ -85,7 +85,8 @@ def display_objects(
                                 2,
                             )
 
-                if box_bool:
+                # Only draw rectangle if it was manually set (not auto-generated)
+                if box_bool and getattr(obj, 'rectangle_visible', True):
                     x0, y0, x1, y1 = tracker2gui(
                         obj.rectangle_path[int(pos - section_start + 1)]
                     )

--- a/src/MotionTrackerBeta/widgets/trackers.py
+++ b/src/MotionTrackerBeta/widgets/trackers.py
@@ -158,7 +158,7 @@ class TrackingThread(QThread):
                 try:
                     ret, roi_box = tracker.update(frame)
                 except Exception as e:
-                    self.error_occured.emit(f"Tracking failed!\n{e}")
+                    self.error_occured.emit(f"Tracking failed!\n{e}\n\nTry adding or changing the rectangle around the point, it might improve tracking.")
                     self.is_running = False
                     break
 
@@ -194,7 +194,7 @@ class TrackingThread(QThread):
                 else:
                     # handle errors
                     self.error_occured.emit(
-                        "Tracking failed!\n Tracker returned with failure!"
+                        "Tracking failed!\n Tracker returned with failure!\n\nTry adding or changing the rectangle around the point, it might improve tracking."
                     )
                     self.is_running = False
 
@@ -351,7 +351,7 @@ class TrackingThreadV2(QThread):
                 try:
                     ret, roi_box = trackers[i].update(frame)
                 except Exception as e:
-                    self.error_occured.emit(f"Tracking failed!\n{e}")
+                    self.error_occured.emit(f"Tracking failed!\n{e}\n\nTry adding or changing the rectangle around the point, it might improve tracking.")
                     self.is_running = False
                     return
 
@@ -386,7 +386,7 @@ class TrackingThreadV2(QThread):
                 else:
                     # handle errors
                     self.error_occured.emit(
-                        "Tracking failed!\n Tracker returned with failure!"
+                        "Tracking failed!\n Tracker returned with failure!\n\nTry adding or changing the rectangle around the point, it might improve tracking."
                     )
                     self.is_running = False
                     return


### PR DESCRIPTION
When no region is selected, auto-creates a hidden 50x50 bounding box centered on the point. The rectangle is used internally for tracking but not displayed to the user, simplifying the user workflow.